### PR TITLE
Stabilize frontend: keep sessions on refresh, add error boundary, dem…

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,6 +35,7 @@ import AI from "./pages/AI";
 import { socket, PresenceContext } from "./ws";
 import RedirectSpotify from "./pages/RedirectSpotify";
 import SpotifyGuard from "./utils/SpotifyGuard";
+import ErrorBoundary from "./components/ErrorBoundary";
 
 function App() {
   const [user, setUser] = useState(null);
@@ -94,13 +95,6 @@ function App() {
   }, [user]);
 
   useEffect(() => {
-    if (user?.id) {
-      console.log("Registering socket for user:", user.id);
-      socket.emit("register", user.id);
-    }
-  }, [user]);
-
-  useEffect(() => {
     const requestInterceptor = axios.interceptors.request.use(
       (config) => {
         const token = localStorage.getItem("authToken");
@@ -131,15 +125,28 @@ function App() {
     };
   }, []);
 
-  const checkAuth = async () => {
+  const checkAuth = async (attempt = 0) => {
     try {
       const response = await axios.get(`${API_URL}/auth/me`, {
         withCredentials: true,
       });
-      if (response.data.user) {
-        setUser(response.data.user);
-      }
+      // A definitive answer from the server: trust it (user object or null).
+      setUser(response.data.user || null);
     } catch (error) {
+      const status = error.response?.status;
+      // 401/403 mean the token is genuinely invalid/expired -> log out.
+      if (status === 401 || status === 403) {
+        setUser(null);
+        return;
+      }
+      // No status (network error/timeout) or a 5xx usually means the backend
+      // is cold-starting, not that the session is gone. Retry with backoff so
+      // a refresh during a cold start doesn't kick the user out.
+      if (attempt < 4) {
+        const delay = 1000 * Math.pow(2, attempt); // 1s, 2s, 4s, 8s
+        await new Promise((r) => setTimeout(r, delay));
+        return checkAuth(attempt + 1);
+      }
       setUser(null);
     }
   };
@@ -237,6 +244,14 @@ function App() {
     }
   }, [user]);
 
+  // Dashboard pages are reachable without Spotify: connected users see their
+  // real data, everyone else gets clearly-labeled demo data via the `demo` flag.
+  const renderDashboard = (Component) => {
+    if (!user) return <Navigate to="/auth" replace />;
+    if (!spotifyCheckDone) return <div className="app">Loading…</div>;
+    return <Component user={user} demo={!spotifyConnected} />;
+  };
+
   if (loading || auth0Loading) {
     return <div>Loading...</div>;
   }
@@ -245,6 +260,7 @@ function App() {
     <PresenceContext.Provider value={{ online, setOnline, socket }}>
       {!hideNavBar && <NavBar user={user} onLogout={handleLogout} />}
       <div className="app">
+        <ErrorBoundary routeKey={location.pathname}>
         <Routes>
           <Route path="/auth" element={<Auth setUser={setUser} />} />
           <Route path="/" element={<Home />} />
@@ -256,66 +272,32 @@ function App() {
           <Route
             path="/dashboard"
             element={
-              <SpotifyGuard
-                user={user}
-                spotifyConnected={spotifyConnected}
-                spotifyCheckDone={spotifyCheckDone}
-              >
+              user ? (
                 <Navigate to="/dashboard/analytics" replace />
-              </SpotifyGuard>
+              ) : (
+                <Navigate to="/auth" replace />
+              )
             }
           />
 
           <Route
             path="/dashboard/analytics"
-            element={
-              <SpotifyGuard
-                user={user}
-                spotifyConnected={spotifyConnected}
-                spotifyCheckDone={spotifyCheckDone}
-              >
-                <Analytics user={user} />
-              </SpotifyGuard>
-            }
+            element={renderDashboard(Analytics)}
           />
 
           <Route
             path="/dashboard/topartist"
-            element={
-              <SpotifyGuard
-                user={user}
-                spotifyConnected={spotifyConnected}
-                spotifyCheckDone={spotifyCheckDone}
-              >
-                <TopArtist user={user} />
-              </SpotifyGuard>
-            }
+            element={renderDashboard(TopArtist)}
           />
 
           <Route
             path="/dashboard/toptracks"
-            element={
-              <SpotifyGuard
-                user={user}
-                spotifyConnected={spotifyConnected}
-                spotifyCheckDone={spotifyCheckDone}
-              >
-                <TopTracks user={user} />
-              </SpotifyGuard>
-            }
+            element={renderDashboard(TopTracks)}
           />
 
           <Route
             path="/dashboard/myplaylist"
-            element={
-              <SpotifyGuard
-                user={user}
-                spotifyConnected={spotifyConnected}
-                spotifyCheckDone={spotifyCheckDone}
-              >
-                <MyPlaylist user={user} />
-              </SpotifyGuard>
-            }
+            element={renderDashboard(MyPlaylist)}
           />
           <Route
             path="/social"
@@ -354,6 +336,7 @@ function App() {
 
           <Route path="*" element={<NotFound />} />
         </Routes>
+        </ErrorBoundary>
       </div>
     </PresenceContext.Provider>
   );

--- a/src/components/DemoBanner.jsx
+++ b/src/components/DemoBanner.jsx
@@ -1,0 +1,40 @@
+import React, { useState } from "react";
+import axios from "axios";
+import { API_URL } from "../shared";
+import "../style/DemoBanner.css";
+
+// Shown on dashboard sections when the logged-in user has no Spotify connection.
+// Makes it explicit that the numbers are sample data, and offers a one-click
+// path to start the Spotify connection flow.
+const DemoBanner = ({ feature = "stats" }) => {
+  const [connecting, setConnecting] = useState(false);
+
+  const handleConnect = async () => {
+    setConnecting(true);
+    try {
+      const res = await axios.get(`${API_URL}/auth/spotify/login-url`);
+      window.location.href = res.data.authUrl;
+    } catch (e) {
+      setConnecting(false);
+    }
+  };
+
+  return (
+    <div className="demo-banner" role="status">
+      <span className="demo-banner-badge">Sample data</span>
+      <span className="demo-banner-text">
+        You're seeing example {feature} because your account isn't connected to
+        Spotify. Connect Spotify to see your real data.
+      </span>
+      <button
+        className="demo-banner-btn"
+        onClick={handleConnect}
+        disabled={connecting}
+      >
+        {connecting ? "Redirecting…" : "Connect Spotify"}
+      </button>
+    </div>
+  );
+};
+
+export default DemoBanner;

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,0 +1,73 @@
+import React from "react";
+
+// Without a boundary, any error thrown while rendering a single page unmounts
+// the entire React tree and leaves a blank white screen. This contains the
+// failure to a fallback card and lets the user recover without a hard refresh.
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, info) {
+    console.error("Render error caught by ErrorBoundary:", error, info);
+  }
+
+  // Reset error state when navigating to a different route so a crash on one
+  // page doesn't permanently wedge the fallback.
+  componentDidUpdate(prevProps) {
+    if (prevProps.routeKey !== this.props.routeKey && this.state.hasError) {
+      this.setState({ hasError: false, error: null });
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div
+          style={{
+            padding: "2rem",
+            color: "#e0ffe0",
+            textAlign: "center",
+            maxWidth: 520,
+            margin: "4rem auto",
+          }}
+        >
+          <h2 style={{ color: "#1db954" }}>Something went wrong on this page</h2>
+          <p style={{ opacity: 0.85 }}>
+            The rest of the app is still working. Try going back, or reload to
+            recover.
+          </p>
+          <div style={{ display: "flex", gap: "0.75rem", justifyContent: "center", marginTop: "1.25rem" }}>
+            <button
+              onClick={() => this.setState({ hasError: false, error: null })}
+              style={btnStyle}
+            >
+              Try again
+            </button>
+            <button onClick={() => (window.location.href = "/")} style={btnStyle}>
+              Go home
+            </button>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+const btnStyle = {
+  background: "#1db954",
+  color: "#06210f",
+  border: "none",
+  borderRadius: 999,
+  padding: "0.5rem 1.25rem",
+  fontWeight: 700,
+  cursor: "pointer",
+};
+
+export default ErrorBoundary;

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -199,7 +199,14 @@ const Login = ({ setUser }) => {
           {/* Note about Spotify access */}
           <div className="spotify-note">
             <p className="spotify-note-text">
-              For full access to all features
+              Spotify sign-in is invite-only right now
+            </p>
+            <p className="spotify-note-subtext">
+              While the app is in Spotify's Development Mode, only a few
+              pre-approved Spotify accounts can connect. New here? Sign up with
+              an email below — you'll get the full social experience, and the
+              music dashboard will show sample data until your Spotify account
+              is approved.
             </p>
           </div>
 

--- a/src/components/RecommendationsOfTheDay.jsx
+++ b/src/components/RecommendationsOfTheDay.jsx
@@ -2,15 +2,21 @@ import React, { useEffect, useState } from "react";
 import axios from "axios";
 import { API_URL } from "../shared";
 import SpotifyEmbed from "./SpotifyEmbed";
+import { DEMO_RECOMMENDATIONS } from "../demoData";
 import "../style/RecommendationsOfTheDay.css";
 
-const RecommendationsOfTheDay = () => {
-  const [tracks, setTracks] = useState([]);
-  const [loading, setLoading] = useState(true);
+const RecommendationsOfTheDay = ({ demo = false }) => {
+  const [tracks, setTracks] = useState(demo ? DEMO_RECOMMENDATIONS : []);
+  const [loading, setLoading] = useState(!demo);
   const [error, setError] = useState(null);
   const [currentIndex, setCurrentIndex] = useState(0);
 
   useEffect(() => {
+    if (demo) {
+      setTracks(DEMO_RECOMMENDATIONS);
+      setLoading(false);
+      return;
+    }
     axios
       .get(`${API_URL}/auth/spotify/ai-recommendations`, { withCredentials: true }) //add s
       .then((res) => {
@@ -21,7 +27,7 @@ const RecommendationsOfTheDay = () => {
         setError("Failed to fetch recommendations");
         setLoading(false);
       });
-  }, []);
+  }, [demo]);
 
   const handlePrev = () => {
     setCurrentIndex((prev) => (prev === 0 ? tracks.length - 1 : prev - 1));

--- a/src/components/TopGenresAndArtists.jsx
+++ b/src/components/TopGenresAndArtists.jsx
@@ -3,17 +3,24 @@ import axios from "axios";
 import { API_URL } from "../shared";
 import GenreCharts from "./GenreCharts";
 import GenreDetail from "./GenreDetail";
+import { DEMO_TOP_GENRES, DEMO_ARTISTS_BY_GENRE } from "../demoData";
 import "../style/TopGenresAndArtists.css";
 
-const TopGenresAndArtists = () => {
-  const [topGenres, setTopGenres] = useState([]);
-  const [artistsByGenre, setArtistsByGenre] = useState({});
-  const [loading, setLoading] = useState(true);
+const TopGenresAndArtists = ({ demo = false }) => {
+  const [topGenres, setTopGenres] = useState(demo ? DEMO_TOP_GENRES : []);
+  const [artistsByGenre, setArtistsByGenre] = useState(demo ? DEMO_ARTISTS_BY_GENRE : {});
+  const [loading, setLoading] = useState(!demo);
   const [error, setError] = useState(null);
   const [selectedGenre, setSelectedGenre] = useState(null);
   const [chartType, setChartType] = useState("pie");
 
   useEffect(() => {
+    if (demo) {
+      setTopGenres(DEMO_TOP_GENRES);
+      setArtistsByGenre(DEMO_ARTISTS_BY_GENRE);
+      setLoading(false);
+      return;
+    }
     axios
       .get(`${API_URL}/auth/spotify/history`, { withCredentials: true })
       .then((res) => {
@@ -31,7 +38,7 @@ const TopGenresAndArtists = () => {
         }
         setLoading(false);
       });
-  }, []);
+  }, [demo]);
 
   const handleChartClick = (genre) => {
     setSelectedGenre(genre);

--- a/src/components/UserListeningHistory.jsx
+++ b/src/components/UserListeningHistory.jsx
@@ -2,15 +2,21 @@ import React, { useEffect, useState } from "react";
 import axios from "axios";
 import { API_URL } from "../shared";
 import UserListeningHistoryEmbeds from "./UserListeningHistoryEmbeds";
+import { DEMO_RECENT_TRACKS } from "../demoData";
 import '../style/UserListeningHistory.css';
 
-const UserListeningHistory = () => {
-  const [recentTracks, setRecentTracks] = useState([]);
-  const [loading, setLoading] = useState(true);
+const UserListeningHistory = ({ demo = false }) => {
+  const [recentTracks, setRecentTracks] = useState(demo ? DEMO_RECENT_TRACKS : []);
+  const [loading, setLoading] = useState(!demo);
   const [error, setError] = useState(null);
   const [collapsed, setCollapsed] = useState(false);
 
   useEffect(() => {
+    if (demo) {
+      setRecentTracks(DEMO_RECENT_TRACKS);
+      setLoading(false);
+      return;
+    }
     axios
       .get(`${API_URL}/auth/spotify/history`, { withCredentials: true })
       .then((res) => {
@@ -25,7 +31,7 @@ const UserListeningHistory = () => {
         }
         setLoading(false);
       });
-  }, []);
+  }, [demo]);
 
   const getTimeAgo = (dateString) => {
     const now = new Date();

--- a/src/components/ai-playlist.jsx
+++ b/src/components/ai-playlist.jsx
@@ -10,6 +10,15 @@ const ChatComponent = () => {
   const [aiTyping, setAiTyping] = useState("");
   const messagesEndRef = useRef(null);
   const textareaRef = useRef(null);
+  const typeIntervalRef = useRef(null);
+
+  // Clear the typewriter interval if the component unmounts mid-animation,
+  // otherwise it keeps calling setState on an unmounted component.
+  useEffect(() => {
+    return () => {
+      if (typeIntervalRef.current) clearInterval(typeIntervalRef.current);
+    };
+  }, []);
 
   useEffect(() => {
     if (textareaRef.current) {
@@ -54,6 +63,7 @@ const ChatComponent = () => {
         i++;
         if (i > aiText.length) {
           clearInterval(typeInterval);
+          typeIntervalRef.current = null;
 
           setMessages((prev) => [...prev, { text: aiText, sender: "ai" }]);
 
@@ -68,6 +78,7 @@ const ChatComponent = () => {
           setLoading(false);
         }
       }, 18);
+      typeIntervalRef.current = typeInterval;
     } catch (err) {
       setMessages((prev) => [
         ...prev,

--- a/src/demoData.js
+++ b/src/demoData.js
@@ -1,0 +1,73 @@
+// Sample data shown on the dashboard for users who haven't connected Spotify.
+// During Spotify's Development Mode an app can only authorize a handful of
+// allow-listed users, so most new accounts can't pull real listening data.
+// These fixtures let them explore the dashboard with clearly-labeled demo data.
+// Real Spotify track/artist IDs are used so the embeds actually render music.
+
+const minutesAgo = (m) => new Date(Date.now() - m * 60 * 1000).toISOString();
+
+export const DEMO_RECENT_TRACKS = [
+  { track: { id: "0VjIjW4GlU5eMxbDg6jJ7q", name: "Blinding Lights", artists: ["The Weeknd"], album: "After Hours", played_at: minutesAgo(8) } },
+  { track: { id: "463CkQjx2Zk1yXoBuierM9", name: "Levitating", artists: ["Dua Lipa"], album: "Future Nostalgia", played_at: minutesAgo(35) } },
+  { track: { id: "4LRPiXqCikLlN15c3yImP7", name: "As It Was", artists: ["Harry Styles"], album: "Harry's House", played_at: minutesAgo(92) } },
+  { track: { id: "2Fxmhks0bxGSBdJ92vM42m", name: "bad guy", artists: ["Billie Eilish"], album: "WHEN WE ALL FALL ASLEEP, WHERE DO WE GO?", played_at: minutesAgo(180) } },
+  { track: { id: "6Uj1ctrBOjOas8xZXGqKk4", name: "Heat Waves", artists: ["Glass Animals"], album: "Dreamland", played_at: minutesAgo(310) } },
+];
+
+export const DEMO_TOP_GENRES = [
+  { genre: "pop", count: 8 },
+  { genre: "synth-pop", count: 5 },
+  { genre: "indie pop", count: 4 },
+  { genre: "dance pop", count: 3 },
+  { genre: "alternative", count: 2 },
+];
+
+export const DEMO_ARTISTS_BY_GENRE = {
+  pop: [
+    { id: "1Xyo4u8uXC1ZmMpatF05PJ", name: "The Weeknd", popularity: 96, images: [] },
+    { id: "6M2wZ9GZgrQXHCFfjv46we", name: "Dua Lipa", popularity: 92, images: [] },
+    { id: "06HL4z0CvFAxyc27GXpf02", name: "Taylor Swift", popularity: 99, images: [] },
+  ],
+  "synth-pop": [
+    { id: "1Xyo4u8uXC1ZmMpatF05PJ", name: "The Weeknd", popularity: 96, images: [] },
+    { id: "53XhwfbYqKCa1cC15pYq2q", name: "Imagine Dragons", popularity: 88, images: [] },
+  ],
+  "indie pop": [
+    { id: "4yvcSjfu4PC0CYQyLy4wSq", name: "Glass Animals", popularity: 82, images: [] },
+    { id: "6qqNVTkY8uBg9cP3Jd7DAH", name: "Billie Eilish", popularity: 90, images: [] },
+  ],
+  "dance pop": [
+    { id: "6M2wZ9GZgrQXHCFfjv46we", name: "Dua Lipa", popularity: 92, images: [] },
+  ],
+  alternative: [
+    { id: "6KImCVD70vtIoJWnq6nGn3", name: "Harry Styles", popularity: 91, images: [] },
+  ],
+};
+
+export const DEMO_RECOMMENDATIONS = [
+  { id: "6Uj1ctrBOjOas8xZXGqKk4", uri: "spotify:track:6Uj1ctrBOjOas8xZXGqKk4", name: "Heat Waves", artist: "Glass Animals", genre: "indie pop" },
+  { id: "5HCyWlXZPP0y6Gqq8TgA20", uri: "spotify:track:5HCyWlXZPP0y6Gqq8TgA20", name: "STAY", artist: "The Kid LAROI, Justin Bieber", genre: "pop" },
+  { id: "6f3Slt0GbA2bPZlz0aIFXN", uri: "spotify:track:6f3Slt0GbA2bPZlz0aIFXN", name: "The Less I Know The Better", artist: "Tame Impala", genre: "psychedelic pop" },
+  { id: "0e7ipj03S05BNilyu5bRzt", uri: "spotify:track:0e7ipj03S05BNilyu5bRzt", name: "rockstar", artist: "Post Malone", genre: "hip hop" },
+];
+
+export const DEMO_TOP_ARTISTS = [
+  { id: "1Xyo4u8uXC1ZmMpatF05PJ", name: "The Weeknd", genres: ["pop", "synth-pop", "r&b"], popularity: 96, followers: { total: 95000000 }, images: [], external_urls: { spotify: "https://open.spotify.com/artist/1Xyo4u8uXC1ZmMpatF05PJ" }, uri: "spotify:artist:1Xyo4u8uXC1ZmMpatF05PJ" },
+  { id: "6M2wZ9GZgrQXHCFfjv46we", name: "Dua Lipa", genres: ["pop", "dance pop"], popularity: 92, followers: { total: 42000000 }, images: [], external_urls: { spotify: "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we" }, uri: "spotify:artist:6M2wZ9GZgrQXHCFfjv46we" },
+  { id: "6KImCVD70vtIoJWnq6nGn3", name: "Harry Styles", genres: ["pop", "alternative"], popularity: 91, followers: { total: 38000000 }, images: [], external_urls: { spotify: "https://open.spotify.com/artist/6KImCVD70vtIoJWnq6nGn3" }, uri: "spotify:artist:6KImCVD70vtIoJWnq6nGn3" },
+  { id: "6qqNVTkY8uBg9cP3Jd7DAH", name: "Billie Eilish", genres: ["indie pop", "electropop"], popularity: 90, followers: { total: 75000000 }, images: [], external_urls: { spotify: "https://open.spotify.com/artist/6qqNVTkY8uBg9cP3Jd7DAH" }, uri: "spotify:artist:6qqNVTkY8uBg9cP3Jd7DAH" },
+  { id: "4yvcSjfu4PC0CYQyLy4wSq", name: "Glass Animals", genres: ["indie pop", "alternative"], popularity: 82, followers: { total: 6000000 }, images: [], external_urls: { spotify: "https://open.spotify.com/artist/4yvcSjfu4PC0CYQyLy4wSq" }, uri: "spotify:artist:4yvcSjfu4PC0CYQyLy4wSq" },
+];
+
+export const DEMO_PLAYLISTS = [
+  { id: "37i9dQZF1DXcBWIGoYBM5M", name: "Today's Top Hits", description: "The hottest tracks right now.", uri: "spotify:playlist:37i9dQZF1DXcBWIGoYBM5M", tracks: { total: 50 }, owner: { display_name: "Spotify" }, external_urls: { spotify: "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M" } },
+  { id: "37i9dQZF1DX0XUsuxWHRQd", name: "RapCaviar", description: "New music from hip-hop's biggest names.", uri: "spotify:playlist:37i9dQZF1DX0XUsuxWHRQd", tracks: { total: 50 }, owner: { display_name: "Spotify" }, external_urls: { spotify: "https://open.spotify.com/playlist/37i9dQZF1DX0XUsuxWHRQd" } },
+  { id: "37i9dQZF1DX4sWSpwq3LiO", name: "Peaceful Piano", description: "Relax and indulge with beautiful piano pieces.", uri: "spotify:playlist:37i9dQZF1DX4sWSpwq3LiO", tracks: { total: 50 }, owner: { display_name: "Spotify" }, external_urls: { spotify: "https://open.spotify.com/playlist/37i9dQZF1DX4sWSpwq3LiO" } },
+];
+
+export const DEMO_TOP_TRACKS = [
+  { id: "0VjIjW4GlU5eMxbDg6jJ7q", name: "Blinding Lights", uri: "spotify:track:0VjIjW4GlU5eMxbDg6jJ7q", artists: [{ name: "The Weeknd" }], album: { name: "After Hours" }, external_urls: { spotify: "https://open.spotify.com/track/0VjIjW4GlU5eMxbDg6jJ7q" } },
+  { id: "463CkQjx2Zk1yXoBuierM9", name: "Levitating", uri: "spotify:track:463CkQjx2Zk1yXoBuierM9", artists: [{ name: "Dua Lipa" }], album: { name: "Future Nostalgia" }, external_urls: { spotify: "https://open.spotify.com/track/463CkQjx2Zk1yXoBuierM9" } },
+  { id: "4LRPiXqCikLlN15c3yImP7", name: "As It Was", uri: "spotify:track:4LRPiXqCikLlN15c3yImP7", artists: [{ name: "Harry Styles" }], album: { name: "Harry's House" }, external_urls: { spotify: "https://open.spotify.com/track/4LRPiXqCikLlN15c3yImP7" } },
+  { id: "2Fxmhks0bxGSBdJ92vM42m", name: "bad guy", uri: "spotify:track:2Fxmhks0bxGSBdJ92vM42m", artists: [{ name: "Billie Eilish" }], album: { name: "WHEN WE ALL FALL ASLEEP, WHERE DO WE GO?" }, external_urls: { spotify: "https://open.spotify.com/track/2Fxmhks0bxGSBdJ92vM42m" } },
+];

--- a/src/pages/Analytics.jsx
+++ b/src/pages/Analytics.jsx
@@ -3,8 +3,9 @@ import MiniDrawer from '../components/MiniDrawer';
 import UserListeningHistory from '../components/UserListeningHistory';
 import TopGenresAndArtists from '../components/TopGenresAndArtists';
 import RecommendationsOfTheDay from '../components/RecommendationsOfTheDay';
+import DemoBanner from '../components/DemoBanner';
 
-const Analytics = () => {
+const Analytics = ({ demo = false }) => {
   const getGreeting = () => {
     const hour = new Date().getHours();
     if (hour < 12) return "Good morning";
@@ -19,13 +20,14 @@ const Analytics = () => {
         <div className="dashboard-summary">
           <h1 style={{ fontSize: '2.2rem', fontWeight: 700, color: '#1db954', marginBottom: '1.2rem', textShadow: '0 2px 12px rgba(0,0,0,0.18)' }}>{getGreeting()}!</h1>
         </div>
-        <UserListeningHistory />
+        {demo && <DemoBanner feature="listening stats" />}
+        <UserListeningHistory demo={demo} />
         <div style={{ display: 'flex', gap: '1rem', alignItems: 'stretch', flexWrap: 'wrap', minHeight: '0' }}>
           <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
-            <TopGenresAndArtists />
+            <TopGenresAndArtists demo={demo} />
           </div>
           <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
-            <RecommendationsOfTheDay />
+            <RecommendationsOfTheDay demo={demo} />
           </div>
         </div>
       </div>

--- a/src/pages/myPlaylist.jsx
+++ b/src/pages/myPlaylist.jsx
@@ -5,10 +5,12 @@ import { useNavigate } from "react-router-dom";
 import "../style/MyPlaylist.css";
 import MiniDrawer from "../components/MiniDrawer";
 import SpotifyEmbed from "../components/SpotifyEmbed";
+import DemoBanner from "../components/DemoBanner";
+import { DEMO_PLAYLISTS } from "../demoData";
 
-const MyPlaylist = ({ user }) => {
-  const [playlists, setPlaylists] = useState([]);
-  const [loading, setLoading] = useState(true);
+const MyPlaylist = ({ user, demo = false }) => {
+  const [playlists, setPlaylists] = useState(demo ? DEMO_PLAYLISTS : []);
+  const [loading, setLoading] = useState(!demo);
   const [error, setError] = useState("");
   const navigate = useNavigate();
 
@@ -17,8 +19,13 @@ const MyPlaylist = ({ user }) => {
       navigate("/auth");
       return;
     }
+    if (demo) {
+      setPlaylists(DEMO_PLAYLISTS);
+      setLoading(false);
+      return;
+    }
     fetchPlaylists();
-  }, [user, navigate]);
+  }, [user, navigate, demo]);
 
   const fetchPlaylists = async () => {
     try {
@@ -95,6 +102,8 @@ const MyPlaylist = ({ user }) => {
             <p style={{ color: '#b6ffb6', fontWeight: 600 }}>Your personal music collections, {user.username}!</p>
           </div>
 
+          {demo && <DemoBanner feature="playlists" />}
+
           {error && (
             <div className="error-message">
               <p>{error}</p>
@@ -129,10 +138,10 @@ const MyPlaylist = ({ user }) => {
                                 "No description available"}
                             </p>
                             <p className="track-count">
-                              {playlist.tracks.total} tracks
+                              {playlist.tracks?.total ?? 0} tracks
                             </p>
                             <p className="owner">
-                              By: {playlist.owner.display_name}
+                              By: {playlist.owner?.display_name ?? "Unknown"}
                             </p>
                             {playlist.external_urls?.spotify && (
                               <a

--- a/src/pages/topArtist.jsx
+++ b/src/pages/topArtist.jsx
@@ -4,10 +4,12 @@ import { API_URL } from '../shared';
 import { useNavigate } from 'react-router-dom';
 import '../style/TopArtist.css';
 import MiniDrawer from '../components/MiniDrawer';
+import DemoBanner from '../components/DemoBanner';
+import { DEMO_TOP_ARTISTS } from '../demoData';
 
-const TopArtist = ({ user }) => {
-  const [topArtists, setTopArtists] = useState([]);
-  const [loading, setLoading] = useState(true);
+const TopArtist = ({ user, demo = false }) => {
+  const [topArtists, setTopArtists] = useState(demo ? DEMO_TOP_ARTISTS : []);
+  const [loading, setLoading] = useState(!demo);
   const [error, setError] = useState('');
   const [timeRange, setTimeRange] = useState('medium_term');
   const navigate = useNavigate();
@@ -17,8 +19,13 @@ const TopArtist = ({ user }) => {
       navigate('/auth');
       return;
     }
+    if (demo) {
+      setTopArtists(DEMO_TOP_ARTISTS);
+      setLoading(false);
+      return;
+    }
     fetchTopArtists();
-  }, [user, navigate, timeRange]);
+  }, [user, navigate, timeRange, demo]);
 
   const fetchTopArtists = async () => {
     try {
@@ -100,6 +107,8 @@ const TopArtist = ({ user }) => {
             <p style={{ color: '#b6ffb6', fontWeight: 600 }}>Discover your most listened to artists, {user.username}!</p>
           </div>
 
+          {demo && <DemoBanner feature="top artists" />}
+
           {error && (
             <div className="error-message">
               <p>{error}</p>
@@ -143,14 +152,14 @@ const TopArtist = ({ user }) => {
                       )}
                       <h4 style={{ color: '#e0ffe0', margin: '0.5rem 0 0.2rem 0', fontWeight: 700 }}>{artist.name}</h4>
                       <div className="artist-genres">
-                        {artist.genres.slice(0, 3).map((genre, idx) => (
+                        {(artist.genres || []).slice(0, 3).map((genre, idx) => (
                           <span key={idx} className="genre-tag">
                             {genre}
                           </span>
                         ))}
                       </div>
                       <p className="popularity">Popularity: {artist.popularity}%</p>
-                      <p className="followers">{artist.followers.total.toLocaleString()} followers</p>
+                      <p className="followers">{artist.followers?.total?.toLocaleString() ?? "—"} followers</p>
                       {artist.external_urls?.spotify && (
                         <a 
                           href={artist.external_urls.spotify} 

--- a/src/pages/topTracks.jsx
+++ b/src/pages/topTracks.jsx
@@ -6,10 +6,12 @@ import "../style/TopTracks.css";
 import MiniDrawer from "../components/MiniDrawer";
 import SearchComponent from "../components/SearchComponent";
 import SpotifyEmbed from "../components/SpotifyEmbed";
+import DemoBanner from "../components/DemoBanner";
+import { DEMO_TOP_TRACKS } from "../demoData";
 
-const TopTracks = ({ user }) => {
-  const [topTracks, setTopTracks] = useState([]);
-  const [loading, setLoading] = useState(true);
+const TopTracks = ({ user, demo = false }) => {
+  const [topTracks, setTopTracks] = useState(demo ? DEMO_TOP_TRACKS : []);
+  const [loading, setLoading] = useState(!demo);
   const [error, setError] = useState("");
   const [timeRange, setTimeRange] = useState("medium_term");
   const navigate = useNavigate();
@@ -19,8 +21,13 @@ const TopTracks = ({ user }) => {
       navigate("/auth");
       return;
     }
+    if (demo) {
+      setTopTracks(DEMO_TOP_TRACKS);
+      setLoading(false);
+      return;
+    }
     fetchTopTracks();
-  }, [user, navigate, timeRange]);
+  }, [user, navigate, timeRange, demo]);
 
   const fetchTopTracks = async () => {
     try {
@@ -112,6 +119,8 @@ const TopTracks = ({ user }) => {
             </p>
           </div>
 
+          {demo && <DemoBanner feature="top tracks" />}
+
           {error && (
             <div className="error-message">
               <p>{error}</p>
@@ -160,11 +169,11 @@ const TopTracks = ({ user }) => {
                           <div className="fallback-content">
                             <h4>{track.name}</h4>
                             <p>
-                              {track.artists
+                              {(track.artists || [])
                                 .map((artist) => artist.name)
                                 .join(", ")}
                             </p>
-                            <p className="album-name">{track.album.name}</p>
+                            <p className="album-name">{track.album?.name}</p>
                             {track.external_urls?.spotify && (
                               <a
                                 href={track.external_urls.spotify}

--- a/src/style/DemoBanner.css
+++ b/src/style/DemoBanner.css
@@ -1,0 +1,52 @@
+.demo-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  background: linear-gradient(90deg, rgba(29, 185, 84, 0.18) 0%, rgba(20, 83, 45, 0.18) 100%);
+  border: 1px solid rgba(29, 185, 84, 0.5);
+  border-radius: 10px;
+  padding: 0.7rem 1rem;
+  margin: 0 0 1.2rem 0;
+  color: #e0ffe0;
+  font-size: 0.95rem;
+}
+
+.demo-banner-badge {
+  flex: 0 0 auto;
+  background: #1db954;
+  color: #06210f;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+}
+
+.demo-banner-text {
+  flex: 1 1 240px;
+  line-height: 1.4;
+}
+
+.demo-banner-btn {
+  flex: 0 0 auto;
+  background: #1db954;
+  color: #06210f;
+  border: none;
+  border-radius: 999px;
+  padding: 0.45rem 1.1rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.demo-banner-btn:hover:not(:disabled) {
+  background: #1ed760;
+  transform: translateY(-1px);
+}
+
+.demo-banner-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}

--- a/src/style/Login.css
+++ b/src/style/Login.css
@@ -91,6 +91,14 @@
   color: #22c55e;
   text-align: center;
   font-size: 0.95rem;
+  font-weight: 600;
+}
+.spotify-note-subtext {
+  color: #cbd5c5;
+  text-align: center;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  margin-top: 0.4rem;
 }
 
 .oauth-section {


### PR DESCRIPTION
…o dashboard

Fixes three classes of finicky behavior reported by users:

1. Refresh logs you out checkAuth() called setUser(null) on ANY /auth/me failure, so a cold-start timeout or network blip during a refresh dropped the session. Now it only logs out on a real 401/403 and retries (1s/2s/4s/8s backoff) on network or 5xx errors, surviving Render cold starts. Also removed a duplicate socket register effect.

2. Certain pages crash the whole app There was no React error boundary, so one thrown render error white-screened everything. Added <ErrorBoundary> around the routes (resets on navigation), and fixed the specific crashers that assumed Spotify response shapes:
   - topArtist: artist.genres.slice / artist.followers.total
   - topTracks: track.artists.map / track.album.name
   - myPlaylist: playlist.tracks.total / playlist.owner.display_name Also cleaned up a setInterval leak in ai-playlist that ran after unmount.

3. New users hit a dead end on the music dashboard Spotify is invite-only in Development Mode (only a few allow-listed accounts can connect), so most new users couldn't see the dashboard at all. Now:
   - Login page explains the limitation and points new users to email signup.
   - Dashboard pages no longer redirect non-Spotify users away; they render clearly-labeled sample data (src/demoData.js) with a <DemoBanner> that offers a one-click Connect Spotify action.

Removed the empty AddFriendFrom.jsx ghost file.